### PR TITLE
chore: Updated override to ignore terraform versions

### DIFF
--- a/aws/fedora-coreos/kubernetes/override.tf
+++ b/aws/fedora-coreos/kubernetes/override.tf
@@ -1,6 +1,7 @@
-terraform {
-  required_version = ">= 0.13.0"
-}
+# Ignoring since Typhoon is now supporting 0.14.x
+//terraform {
+//  required_version = ">= 0.13.0"
+//}
 
 variable "az-zone-match" {
   default = ["eu-west-1a"]
@@ -43,10 +44,6 @@ resource "aws_route_table_association" "public" {
 output "kubeconfig" {
   value     = module.bootstrap.kubeconfig-kubelet
   sensitive = false
-}
-
-module "bootstrap" {
-  source = "../../../../terraform-render-bootstrap"
 }
 
 data "aws_ami" "fedora-coreos" {

--- a/aws/fedora-coreos/kubernetes/workers/override.tf
+++ b/aws/fedora-coreos/kubernetes/workers/override.tf
@@ -1,3 +1,24 @@
-terraform {
-  required_version = ">= 0.13.0"
+# Ignoring since Typhoon is now supporting 0.14.x
+//terraform {
+//  required_version = ">= 0.13.0"
+//}
+
+data "aws_ami" "fedora-coreos" {
+  most_recent = true
+  owners      = ["125523088429"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "description"
+    values = ["Fedora CoreOS ${var.os_stream} 31*"]
+  }
 }

--- a/aws/flatcar-linux/kubernetes/override.tf
+++ b/aws/flatcar-linux/kubernetes/override.tf
@@ -1,6 +1,7 @@
-terraform {
-  required_version = ">= 0.13.0"
-}
+# Ignoring since Typhoon is now supporting 0.14.x
+//terraform {
+//  required_version = ">= 0.13.0"
+//}
 
 variable "az-zone-match" {
   default = ["eu-west-1a"]

--- a/aws/flatcar-linux/kubernetes/workers/override.tf
+++ b/aws/flatcar-linux/kubernetes/workers/override.tf
@@ -1,3 +1,4 @@
-terraform {
-  required_version = ">= 0.13.0"
-}
+# Ignoring since Typhoon is now supporting 0.14.x
+//terraform {
+//  required_version = ">= 0.13.0"
+//}


### PR DESCRIPTION
- [x] Ignoring the Terraform version override since the Typhoon is now supporting v0.14.x